### PR TITLE
Handle zero array size when deserializing symbol

### DIFF
--- a/src/cc/eval.h
+++ b/src/cc/eval.h
@@ -210,7 +210,9 @@ public:
     void SerSymbol(Stream& s, CSerActionUnserialize act)
     {
         size_t readlen = std::min(sizeof(symbol), s.size());
-        char *nullPos = (char*) memchr(&s[0], 0, readlen);
+        char *nullPos = nullptr;
+        if (readlen > 0)
+           nullPos = (char*) memchr(&s[0], 0, readlen);
         if (!nullPos)
             throw std::ios_base::failure("couldn't parse symbol");
         s.read(symbol, nullPos-&s[0]+1);


### PR DESCRIPTION
I probably was in the middle of writing a block to disk when I exited the daemon. Upon restart, deserializing caused a core dump.

The fix below throws an exception (which is handled) instead of dumping core.

ToDo:
- [ ] Verify the block gets downloaded again instead of processing simply continuing with inaccurate data.